### PR TITLE
Fixes #23

### DIFF
--- a/sr_ronex_transmissions/example/ronex.urdf
+++ b/sr_ronex_transmissions/example/ronex.urdf
@@ -9,10 +9,10 @@
     <child link="link2"/>
   </joint>
 
-  <!-- transmission type="sr_ronex_transmissions/RonexTransmission" name="my_ronex_transmission">
+  <transmission type="sr_ronex_transmissions/RonexTransmission" name="my_ronex_transmission">
     <joint name="joint1"/>
     <mapping ronex="ronex_33554433_0" property="position" analogue_pin="0" scale="1.0" offset="0.0"/>
     <mapping ronex="ronex_33554433_0" property="effort"   analogue_pin="1" scale="2.0" offset="1.0"/>
-    <mapping ronex="ronex_33554433_0" property="command" pwm_module="1" pwm_pin="0"/>
-  </transmission -->
+    <mapping ronex="ronex_33554433_0" property="command" pwm_module="1" pwm_pin="0" direction_pin="5"/>
+  </transmission>
 </robot>

--- a/sr_ronex_transmissions/include/sr_ronex_transmissions/mapping/general_io/command_to_pwm.hpp
+++ b/sr_ronex_transmissions/include/sr_ronex_transmissions/mapping/general_io/command_to_pwm.hpp
@@ -52,8 +52,10 @@ namespace ronex
         ///Pointer to the GeneralIO module we specified in the transmission.
         GeneralIO* general_io_;
         ///PWM module index and PWM pin (0 or 1) as we have 2 pins per pwm_module_
-        size_t pwm_module_, pin_index_;
-        ///Are the pwm_module_ and pin_index_ in the correct ranges?
+        size_t pwm_module_, pwm_pin_index_;
+        ///digital pin index for the motor direction digital pin
+        size_t digital_pin_index_;
+        ///Are the pwm_module_, pwm_pin_index_ and digital_pin_index_ in the correct ranges?
         bool pin_out_of_bound_;
 
         ///Those are used for computing the PWM on time / PWM period

--- a/sr_ronex_transmissions/src/mapping/general_io/command_to_pwm.cpp
+++ b/sr_ronex_transmissions/src/mapping/general_io/command_to_pwm.cpp
@@ -141,7 +141,6 @@ namespace ronex
 
         if( check_pins_in_bound_() )
         {
-          ROS_ERROR_STREAM("pin in bound");
           if( pwm_pin_index_ == 0 )
             general_io_->command_.pwm_[pwm_module_].on_time_0 = static_cast<unsigned short int>((static_cast<double>(general_io_->command_.pwm_[pwm_module_].period) * js[0]->commanded_effort_ ) / 100);
           else

--- a/sr_ronex_transmissions/test/test_ronex_transmission.cpp
+++ b/sr_ronex_transmissions/test/test_ronex_transmission.cpp
@@ -89,7 +89,7 @@ TEST(RonexTransmission, propagateCommand)
 
   //reading the command from the RoNeX
   EXPECT_EQ(general_io->command_.pwm_[1].on_time_0, 3264);
-
+  EXPECT_FALSE(general_io->command_.digital_[5]);  //Positive commanded effort should set direction pin to 0
 }
 
 

--- a/sr_ronex_utilities/CMakeLists.txt
+++ b/sr_ronex_utilities/CMakeLists.txt
@@ -124,10 +124,9 @@ install(DIRECTORY include/${PROJECT_NAME}/
 #############
 
 ## Add gtest based cpp test target and link libraries
-catkin_add_gtest(${PROJECT_NAME}-test test/test_sr_ronex_utilities.cpp)
-if(TARGET ${PROJECT_NAME}-test)
-   target_link_libraries(${PROJECT_NAME}-test ${catkin_LIBRARIES})
-endif()
+add_rostest_gtest(test_ronex_utilities test/test_ronex_utilities.test test/test_sr_ronex_utilities.cpp)
+target_link_libraries(test_ronex_utilities ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
+
 
 ## Add folders to be run by python nosetests
 # catkin_add_nosetests(test)

--- a/sr_ronex_utilities/test/test_ronex_utilities.test
+++ b/sr_ronex_utilities/test/test_ronex_utilities.test
@@ -1,0 +1,3 @@
+<launch>
+  <test test-name="test_ronex_utilities" pkg="sr_ronex_utilities" type="test_ronex_utilities"/>
+</launch>


### PR DESCRIPTION
Now the motor effort sign is mapped to a digital pin that will control the direction of the motor rotation.
Additionally, test in sr_ronex_utilities is called as a rostest_gtest.
