### PR TITLE
Fixes #104 - fixes transmission check_pin_in_bound_

### DIFF
--- a/sr_ronex_transmissions/include/sr_ronex_transmissions/mapping/general_io/analogue_to_position.hpp
+++ b/sr_ronex_transmissions/include/sr_ronex_transmissions/mapping/general_io/analogue_to_position.hpp
@@ -1,16 +1,16 @@
 /*
  * Copyright (c) 2013, Shadow Robot Company, All rights reserved.
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3.0 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library.
  */
@@ -18,7 +18,7 @@
 /**
  * @file   analogue_to_position.hpp
  * @author Ugo Cupcic <ugo@shadowrobot.com>
- * @brief  Contains the data mapping one pin of a GIO module to the position 
+ * @brief  Contains the data mapping one pin of a GIO module to the position
  *         of the joint.
  **/
 
@@ -38,7 +38,8 @@ namespace ronex
         : public RonexMapping
       {
       public:
-        AnalogueToPosition() {};
+        AnalogueToPosition()
+         : RonexMapping() {};
         AnalogueToPosition(TiXmlElement* mapping_el, pr2_mechanism_model::Robot* robot);
         virtual ~AnalogueToPosition();
 

--- a/sr_ronex_transmissions/include/sr_ronex_transmissions/mapping/general_io/command_to_pwm.hpp
+++ b/sr_ronex_transmissions/include/sr_ronex_transmissions/mapping/general_io/command_to_pwm.hpp
@@ -1,16 +1,16 @@
 /*
  * Copyright (c) 2013, Shadow Robot Company, All rights reserved.
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3.0 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library.
  */
@@ -37,7 +37,10 @@ namespace ronex
         : public RonexMapping
       {
       public:
-        CommandToPWM() {};
+        CommandToPWM()
+          : RonexMapping()
+        {};
+
         CommandToPWM(TiXmlElement* mapping_el, pr2_mechanism_model::Robot* robot);
         virtual ~CommandToPWM();
 

--- a/sr_ronex_transmissions/include/sr_ronex_transmissions/mapping/ronex_mapping.hpp
+++ b/sr_ronex_transmissions/include/sr_ronex_transmissions/mapping/ronex_mapping.hpp
@@ -1,16 +1,16 @@
 /*
  * Copyright (c) 2013, Shadow Robot Company, All rights reserved.
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3.0 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library.
  */
@@ -18,7 +18,7 @@
 /**
  * @file   ronex_mapping.hpp
  * @author Ugo Cupcic <ugo@shadowrobot.com>
- * @brief  Base class, contains the data mapping one element of a RoNeX to 
+ * @brief  Base class, contains the data mapping one element of a RoNeX to
  *         a joint element.
  **/
 
@@ -32,7 +32,9 @@ namespace ronex
   class RonexMapping
   {
   public:
-    RonexMapping() {};
+    RonexMapping()
+      : first_iteration_(true)
+    {};
     RonexMapping(TiXmlElement* mapping_el) {};
     RonexMapping(TiXmlElement* mapping_el, pr2_mechanism_model::Robot* robot) {};
     virtual ~RonexMapping() {};
@@ -52,6 +54,9 @@ namespace ronex
      * @param js Current joint states.
      */
     virtual void propagateToRonex(std::vector<pr2_mechanism_model::JointState*>& js) = 0;
+
+  protected:
+    bool first_iteration_;
   };
 }
 

--- a/sr_ronex_transmissions/src/mapping/general_io/analogue_to_position.cpp
+++ b/sr_ronex_transmissions/src/mapping/general_io/analogue_to_position.cpp
@@ -32,7 +32,7 @@ namespace ronex
     namespace general_io
     {
       AnalogueToPosition::AnalogueToPosition(TiXmlElement* mapping_el, pr2_mechanism_model::Robot* robot)
-        : pin_out_of_bound_(true)
+        : RonexMapping(), pin_out_of_bound_(true)
       {
         const char *ronex_name = mapping_el ? mapping_el->Attribute("ronex") : NULL;
         if (!ronex_name)
@@ -120,6 +120,14 @@ namespace ronex
 
       bool AnalogueToPosition::check_pin_in_bound_()
       {
+        //we ignore the first iteration as the array is not yet initialised.
+        if( first_iteration_ )
+        {
+          pin_out_of_bound_ = true;
+          first_iteration_ = false;
+          return false;
+        }
+
         //we have to check here for the size otherwise the general io hasn't been updated.
         if( pin_out_of_bound_ )
         {

--- a/sr_ronex_transmissions/src/mapping/general_io/command_to_pwm.cpp
+++ b/sr_ronex_transmissions/src/mapping/general_io/command_to_pwm.cpp
@@ -33,7 +33,7 @@ namespace ronex
     namespace general_io
     {
       CommandToPWM::CommandToPWM(TiXmlElement* mapping_el, pr2_mechanism_model::Robot* robot)
-        : pin_out_of_bound_(true)
+        : RonexMapping(), pin_out_of_bound_(true)
       {
         const char *ronex_name = mapping_el ? mapping_el->Attribute("ronex") : NULL;
         if (!ronex_name)
@@ -110,6 +110,14 @@ namespace ronex
 
       bool CommandToPWM::check_pins_in_bound_()
       {
+        //we ignore the first iteration as the array is not yet initialised.
+        if( first_iteration_ )
+        {
+          pin_out_of_bound_ = true;
+          first_iteration_ = false;
+          return false;
+        }
+
         //we have to check here for the size otherwise the general io hasn't been updated.
         if( pin_out_of_bound_ )
         {


### PR DESCRIPTION
During the first iteration, the state analogue / etc... vectors appear not to be initialised yet. This throws a misleading error message from the check_pin_in_bound_ function. Add a if first iteration -> ignore in the function to remove the error.
