### PR TITLE
propagating the robot description 

### DIFF
--- a/sr_ronex_launch/launch/sr_ronex_no_controllers.launch
+++ b/sr_ronex_launch/launch/sr_ronex_no_controllers.launch
@@ -1,12 +1,15 @@
 <launch>
   <!-- Allows to specify the ethernet interface to be used. It defaults to the value of the env var ETHERCAT_PORT -->
   <arg name="ethercat_port" default="$(optenv ETHERCAT_PORT eth0)"/>
+  <arg name="robot_description" default="$(find sr_ronex_launch)/loaders/ronex.urdf.xacro"/>
 
   <!-- Set to true for debugging -->
   <arg name="debug" default="false"/>
 
   <!-- Loads the robot description -->
-  <include file="$(find sr_ronex_launch)/loaders/load_ronex_model.launch"/>
+  <include file="$(find sr_ronex_launch)/loaders/load_ronex_model.launch">
+    <arg name="robot_description" value="$(arg robot_description)"/>
+  </include>
 
   <!-- etherCAT -->
   <group if="$(arg debug)">

--- a/sr_ronex_launch/loaders/load_ronex_model.launch
+++ b/sr_ronex_launch/loaders/load_ronex_model.launch
@@ -1,3 +1,5 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro.py '$(find sr_ronex_launch)/loaders/ronex.urdf.xacro'" />
+  <arg name="robot_description" default="$(find sr_ronex_launch)/loaders/ronex.urdf.xacro"/>
+
+  <param name="robot_description" command="$(find xacro)/xacro.py '$(arg robot_description)'" />
 </launch>


### PR DESCRIPTION
 makes it easier to use the launch in a robot launch file (instead of copying the command for running the ronex).
